### PR TITLE
Fix PHP 8.4 implicit nullable type deprecation

### DIFF
--- a/src/Item.php
+++ b/src/Item.php
@@ -30,7 +30,7 @@ class Item implements ItemInterface
 		Destination|null $destination = null,
 		string|null $resource = null,
 		int $sortPriority = 10,
-		string $icon = null,
+		?string $icon = null,
 		ItemInterface ...$items
 	)
 	{


### PR DESCRIPTION
## Summary
- Fix implicit nullable parameter `string $icon = null` → `?string $icon = null` in `Item.php`
- PHP 8.4 deprecated implicitly nullable types, causing `E_DEPRECATED` warnings that break strict error handling

## Context
PHP 8.4 requires explicit nullable types. The old syntax `string $icon = null` is deprecated and will be removed in PHP 9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)